### PR TITLE
Don't import osproc when os=freertos, prefer gorgeEx

### DIFF
--- a/src/nimbleutils.nim
+++ b/src/nimbleutils.nim
@@ -1,7 +1,10 @@
 import std / [strutils, sequtils, os, compilesettings]
 
 when nimvm: discard
-else: import osproc
+else:
+  when not defined(freertos):
+    # can't import osproc when cross-compiling for freertos
+    import osproc
 
 type
   Backend* = enum C = "c", Cc = "cc", Cpp = "cpp", Objc = "objc", Js = "js"
@@ -41,7 +44,11 @@ proc nimbleDump(package: string): tuple[output: string, exitCode: int] =
   when nimvm:
     gorgeEx("nimble dump " & quoteShell(package))
   else:
-    execCmdEx("nimble dump " & quoteShell(package))
+    when not defined(freertos):
+      # can't import osproc when cross-compiling for freertos
+      execCmdEx("nimble dump " & quoteShell(package))
+    else:
+      gorgeEx("nimble dump " & quoteShell(package))
 
 proc parseVersion(version: string): Version =
   let split = version.split(".")


### PR DESCRIPTION
This fixes a Nim error, can't import osproc module when cross-compiling to freertos (and probably other similar targets).

This forces nimbleDump to use gorgeEx to get version at compile time.